### PR TITLE
update:Dockerfile for using dockerhub to ec2,fix:CORS error

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:11-jdk-slim
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/backend/src/main/java/com/devu/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/devu/backend/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("*"));
+        configuration.setAllowedOriginPatterns(Arrays.asList("*"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);

--- a/backend/src/main/java/com/devu/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/devu/backend/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.devu.backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")      //패턴
+                .allowedOrigins("*")    //URL
+                .allowedOrigins("http://localhost:8080","http://54.180.29.69:8080") //URL
+                .allowedHeaders("header1","header2")  //header
+                .allowedMethods("GET","POST");        //method
+    }
+}


### PR DESCRIPTION
# CORS error 
- `When allowCredentials is true, allowedOrigins cannot contain the special value "*" since that cannot be set on the "Access-Control-Allow-Origin" response header` 에러 발생 
- 원인 : 기존의 security 설정 코드에서 `configuration.setAllowedOrigins`와 WebConfig의 `.allowedOrigins("*")`가 충돌하여 발생
- 해결 : setAllowedOrigins를 setAllowedOriginPatterns 메서드로 대체

# 개발용 서버 배포
- Dockerhub에 로컬에서 build된 jar 파일을 도커 이미지로 전송(Dockerfile 작성)
- 이후 해당 이미지를 ec2 도커에서 pull 땡겨서 실행하면 간단하게 도커를 활용해 개발 환경 구축 가능