### PR TITLE
fix PasswordEncoder and Handling Exception

### DIFF
--- a/backend/src/main/java/com/devu/backend/common/Messages.java
+++ b/backend/src/main/java/com/devu/backend/common/Messages.java
@@ -8,4 +8,6 @@ public class Messages {
     public static final String NO_EMAIL_CONFIRM = "이메일 인증이 완료되지 않은 사용자입니다.";
     public static final String PASSWORD_NOT_EQUAL = "비밀번호가 일치하지 않습니다.";
     public static final String ALREADY_EXIST_EMAIL = "이미 존재하는 이메일입니다.";
+    public static final String WRONG_AUTH_KEY = "입력한 인증키가 일치하지 않습니다.";
 }
+

--- a/backend/src/main/java/com/devu/backend/common/exception/EmailAuthKeyNotEqualException.java
+++ b/backend/src/main/java/com/devu/backend/common/exception/EmailAuthKeyNotEqualException.java
@@ -1,0 +1,9 @@
+package com.devu.backend.common.exception;
+
+import com.devu.backend.common.Messages;
+
+public class EmailAuthKeyNotEqualException extends BusinessException {
+    public EmailAuthKeyNotEqualException() {
+        super(Messages.WRONG_AUTH_KEY);
+    }
+}

--- a/backend/src/main/java/com/devu/backend/controller/user/UserController.java
+++ b/backend/src/main/java/com/devu/backend/controller/user/UserController.java
@@ -30,9 +30,6 @@ public class UserController {
     @PostMapping("/key")
     private ResponseEntity<?> getKeyFromUser(@RequestParam String postKey) {
         User user = userService.getByAuthKey(postKey);
-        if (user == null) {
-            return ResponseEntity.badRequest().body("Wrong AuthKey from User");
-        }
         user.updateEmailConfirm(true);
         userService.updateUserConfirm(user);
         return ResponseEntity.ok(HttpStatus.OK);
@@ -43,6 +40,9 @@ public class UserController {
     @PostMapping("/email")
     private ResponseEntity<?> sendEmail(@RequestParam String email){
         try {
+            if (userService.isEmailConfirmed(email)) {
+                return ResponseEntity.ok().body("이미 가입 완료된 이메일입니다.");
+            }
             if (userService.isEmailExists(email)) {
                 String authKey = emailService.createKey();
                 emailService.sendValidationMail(email, authKey);

--- a/backend/src/main/java/com/devu/backend/controller/user/UserController.java
+++ b/backend/src/main/java/com/devu/backend/controller/user/UserController.java
@@ -81,7 +81,9 @@ public class UserController {
     public ResponseEntity<?> registerUser(@RequestBody UserDTO userCreateRequestDto) {
         try {
             User user = userService.getByEmail(userCreateRequestDto.getEmail());
-            user.updateUserInfo(userCreateRequestDto.getUsername(), userCreateRequestDto.getPassword());
+            user.updateUserInfo(
+                    userCreateRequestDto.getUsername(),
+                    passwordEncoder.encode(userCreateRequestDto.getPassword()));
             User updatedUser = userService.updateUser(user);
             UserDTO userDTO = UserDTO.builder()
                     .email(updatedUser.getEmail())

--- a/backend/src/main/java/com/devu/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/devu/backend/repository/UserRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User,Long> {
     Boolean existsByEmail(String email);
 
-    User findByEmailAuthKey(String authKey);
+    Optional<User> findByEmailAuthKey(String authKey);
 
     Optional<User> findByEmail(String email);
 }

--- a/backend/src/main/java/com/devu/backend/service/UserService.java
+++ b/backend/src/main/java/com/devu/backend/service/UserService.java
@@ -1,9 +1,6 @@
 package com.devu.backend.service;
 
-import com.devu.backend.common.exception.AlreadyExistsEmailException;
-import com.devu.backend.common.exception.EmailConfirmNotCompleteException;
-import com.devu.backend.common.exception.PasswordNotSameException;
-import com.devu.backend.common.exception.UserNotFoundException;
+import com.devu.backend.common.exception.*;
 import com.devu.backend.entity.User;
 import com.devu.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +18,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     public User getByAuthKey(final String authKey) {
-        User user = userRepository.findByEmailAuthKey(authKey);
-        if (user == null) {
-            log.warn("Wrong AuthKey");
-        }
-        return user;
+        return userRepository.findByEmailAuthKey(authKey).orElseThrow(EmailAuthKeyNotEqualException::new);
     }
 
     public User getByEmail(final String email) {
@@ -86,5 +79,10 @@ public class UserService {
             throw new PasswordNotSameException();
         }
         return user;
+    }
+
+    public boolean isEmailConfirmed(final String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+        return user.isEmailConfirm();
     }
 }


### PR DESCRIPTION
# DB에 복호화된 Password가 저장되지 않는 에러 해결 
- 단순히 PasswordEncoder로 encode()하지 않고 update 쿼리날려서 발생
- 간단히 메서드 사용해서 해결

# 예외처리
1) 회원가입을 완료한 이메일로 회원가입 페이지에서 이메일 검증 시 이메일 발송되는 에러
- 간단하게 Controller단에서 isEmailConfirmed()를 통해 해당 이메일 검증 단계 추가
- true 반환시, 이미 존재하는 회원 메세지를 HTTP 바디에 싣어서 전송
2) 잘못된 이메일 Auth Key 입력시에 대한 예외처리 없음
- 잘못된 인증키라는 Exception 발생 시켜서 사용자에게 인식시키기(EmailAuthKeyNotEqualException 예외 생성)