### PR TITLE
feat: Add Hierarchical comments C,R

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,6 +1,13 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'org.springframework.boot' version '2.6.5'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 	id 'java'
 }
 
@@ -27,6 +34,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
 	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.1.RELEASE'
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'
@@ -38,4 +47,20 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }

--- a/backend/src/main/java/com/devu/backend/config/QuerydslConfig.java
+++ b/backend/src/main/java/com/devu/backend/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.devu.backend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/src/main/java/com/devu/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/devu/backend/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                             "/email", "/signup", "/signin", "/silent-refresh",
                             "/community/**","/users","/like",
                             "/password_url_email","/change_password/**",
-                            "/comment/**","/comments/**"
+                            "/comment/**","/comments/**", "/reComment"
                     )
                     .permitAll()
                     .anyRequest().authenticated()

--- a/backend/src/main/java/com/devu/backend/controller/comment/CommentController.java
+++ b/backend/src/main/java/com/devu/backend/controller/comment/CommentController.java
@@ -5,6 +5,9 @@ import com.devu.backend.entity.Comment;
 import com.devu.backend.service.CommentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,14 +26,49 @@ public class CommentController {
             log.info("Post Id : {}",requestDto.getPostId());
             log.info("User Id : {}",requestDto.getUserId());
             Comment comment = commentService.saveComment(requestDto);
-            log.info("Comment ID : {} is created by username : {} where postTitle : {}",
+
+            log.info("Comment ID : {} is created by username : {} where postTitle : {}, group {}",
                     comment.getId(),
                     comment.getUser().getUsername(),
-                    comment.getPost().getTitle());
+                    comment.getPost().getTitle(),
+                    comment.getGroupNum());
+            CommentResponseDto responseDto = CommentResponseDto.builder()
+                    .commentId(comment.getId())
+                    .username(comment.getUser().getUsername())
+                    .contents(comment.getContents())
+                    .title(comment.getPost().getTitle())
+                    .group(comment.getGroupNum())
+                    .build();
+            return ResponseEntity.ok().body(responseDto);
+        } catch (Exception e) {
+            e.printStackTrace();
+            ResponseErrorDto errorDto = ResponseErrorDto.builder()
+                    .error(e.getMessage())
+                    .build();
+            return ResponseEntity.badRequest().body(errorDto);
+        }
+    }
+
+    @PostMapping("/reComment")
+    ResponseEntity<?> createReComment(@RequestBody CommentCreateRequestDto requestDto) {
+        try {
+            log.info("Post Id : {}",requestDto.getPostId());
+            log.info("User Id : {}",requestDto.getUserId());
+            Comment comment = commentService.saveReComment(requestDto);
+
+            log.info("Comment ID : {} is created by username : {} where postTitle : {}, group {}, from who {}",
+                    comment.getId(),
+                    comment.getUser().getUsername(),
+                    comment.getPost().getTitle(),
+                    comment.getGroupNum(),
+                    comment.getParent());
             CommentResponseDto responseDto = CommentResponseDto.builder()
                     .commentId(comment.getId())
                     .username(comment.getUser().getUsername())
                     .title(comment.getPost().getTitle())
+                    .group(comment.getGroupNum())
+                    .contents(comment.getContents())
+                    .parent(comment.getParent())
                     .build();
             return ResponseEntity.ok().body(responseDto);
         } catch (Exception e) {
@@ -43,9 +81,9 @@ public class CommentController {
     }
 
     @GetMapping("/comments/{postId}")
-    ResponseEntity<?> getComments(@PathVariable(name = "postId") Long postId) {
+    ResponseEntity<?> getComments(@PathVariable(name = "postId") Long postId, @PageableDefault(size = 20) Pageable pageable) {
         try {
-            List<Comment> comments = commentService.commentsByPost(postId);
+            List<CommentResponseDto> comments = commentService.commentsByPost(postId, pageable).getContent();
             return ResponseEntity.ok().body(comments);
         }catch (Exception e) {
             e.printStackTrace();

--- a/backend/src/main/java/com/devu/backend/controller/comment/CommentResponseDto.java
+++ b/backend/src/main/java/com/devu/backend/controller/comment/CommentResponseDto.java
@@ -13,4 +13,7 @@ public class CommentResponseDto {
     private String username;
     private String title;
     private Long commentId;
+    private String contents;
+    private Long group;
+    private String parent;
 }

--- a/backend/src/main/java/com/devu/backend/controller/comment/ReCommentCreateRequestDto.java
+++ b/backend/src/main/java/com/devu/backend/controller/comment/ReCommentCreateRequestDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-public class CommentCreateRequestDto {
+public class ReCommentCreateRequestDto {
     private Long userId;
     private Long postId;
     private String contents;

--- a/backend/src/main/java/com/devu/backend/controller/comment/ReCommentResponseDto.java
+++ b/backend/src/main/java/com/devu/backend/controller/comment/ReCommentResponseDto.java
@@ -9,10 +9,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-public class CommentCreateRequestDto {
-    private Long userId;
-    private Long postId;
-    private String contents;
-    private String parent;
+public class ReCommentResponseDto {
+    private String username;
+    private String title;
+    private Long commentId;
     private Long group;
+    private String parent;
 }

--- a/backend/src/main/java/com/devu/backend/entity/Comment.java
+++ b/backend/src/main/java/com/devu/backend/entity/Comment.java
@@ -22,6 +22,11 @@ public class Comment extends BaseTime{
     @Column(nullable = false)
     private String contents;
 
+    private boolean deleted;
+
+    private Long groupNum;
+
+    private String parent;
     /*
     * comment 작성 할때만, User and Post 영속성 전이를 통해 Persist
     * */
@@ -37,7 +42,8 @@ public class Comment extends BaseTime{
         this.contents = contents;
     }
 
-    /*
-    * 댓글 삭제 시 "삭제된 댓글입니다." 흔적 남기기
-    * */
+    public void updateGroup(Long group) {
+        this.groupNum = group;
+    }
+
 }

--- a/backend/src/main/java/com/devu/backend/repository/CommentRepository.java
+++ b/backend/src/main/java/com/devu/backend/repository/CommentRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryExtension {
     List<Comment> findAllByPostIdOrderByCreateAt(Long postId);
 
     void deleteById(Long commentId);

--- a/backend/src/main/java/com/devu/backend/repository/CommentRepositoryExtension.java
+++ b/backend/src/main/java/com/devu/backend/repository/CommentRepositoryExtension.java
@@ -1,0 +1,12 @@
+package com.devu.backend.repository;
+
+import com.devu.backend.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+public interface CommentRepositoryExtension {
+
+    Page<Comment> findByPostId(Long postId, Pageable pageable);
+}

--- a/backend/src/main/java/com/devu/backend/repository/CommentRepositoryExtensionImpl.java
+++ b/backend/src/main/java/com/devu/backend/repository/CommentRepositoryExtensionImpl.java
@@ -1,0 +1,38 @@
+package com.devu.backend.repository;
+
+import com.devu.backend.entity.Comment;
+import com.devu.backend.entity.QComment;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CommentRepositoryExtensionImpl implements CommentRepositoryExtension{
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<Comment> findByPostId(Long postId, Pageable pageable) {
+        QComment comment = QComment.comment;
+        List<Comment> content = queryFactory
+                .selectFrom(comment)
+                .where(comment.post.id.eq(postId))
+                .orderBy(
+                        comment.groupNum.asc(),
+                        comment.id.asc()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Comment> countQuery = queryFactory
+                .selectFrom(comment)
+                .where(comment.post.id.eq(postId));
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+    }
+}

--- a/backend/src/main/java/com/devu/backend/service/CommentService.java
+++ b/backend/src/main/java/com/devu/backend/service/CommentService.java
@@ -14,10 +14,10 @@ import com.devu.backend.repository.CommentRepository;
 import com.devu.backend.repository.PostRepository;
 import com.devu.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -40,6 +40,26 @@ public class CommentService {
                 .post(post)
                 .contents(requestDto.getContents())
                 .build();
+        Comment saveComment = commentRepository.save(comment);
+        comment.updateGroup(saveComment.getId());
+        return saveComment;
+    }
+
+    @Transactional
+    public Comment saveReComment(CommentCreateRequestDto requestDto) {
+        User user = userRepository.findById(requestDto.getUserId()).orElseThrow(UserNotFoundException::new);
+        Post post = postRepository.findById(requestDto.getPostId()).orElseThrow(PostNotFoundException::new);
+        if (requestDto.getContents() == null) {
+            throw new CommentContentNullException();
+        }
+        Comment comment = Comment.builder()
+                .user(user)
+                .post(post)
+                .contents(requestDto.getContents())
+                .groupNum(requestDto.getGroup())
+                .parent(requestDto.getParent())
+                .build();
+
         return commentRepository.save(comment);
     }
 
@@ -50,7 +70,17 @@ public class CommentService {
         return comment;
     }
 
-    public List<Comment> commentsByPost(Long postId) {
-        return commentRepository.findAllByPostIdOrderByCreateAt(postId);
+    public Page<CommentResponseDto> commentsByPost(Long postId, Pageable pageable) {
+        return commentRepository.findByPostId(postId, pageable).map(
+                comment -> CommentResponseDto
+                        .builder()
+                        .username(comment.getUser().getUsername())
+                        .title(comment.getPost().getTitle())
+                        .commentId(comment.getId())
+                        .group(comment.getGroupNum())
+                        .contents(comment.getContents())
+                        .parent(comment.getParent())
+                        .build()
+        );
     }
 }


### PR DESCRIPTION
쓸데없는 컬럼 제거하고 최적화 생각해봄
계층형 댓글 C, R
- groupNum: 그룹번호
- parent: 대댓글시 부모닉네임(String)
- deleted: 삭제컬럼

댓글 생성 순서: 댓글1, 댓글2, 댓글3, 대댓글1, 대댓글2
ex)         id, groupNum 순
댓글1:  1,  1
대댓글1: 4, 1
대댓글2: 5, 1
댓글2: 2, 2
댓글3: 3, 3

프론트에서 댓글 대댓글 구분은 groupNum중 첫번째로 오는것과 아닌것으로 구분

*Querydsl 도입
컴파일전에 compileQuerydsl 실행해서 QEntity 생성해줘야 됨