### PR TITLE
update:getLike Size API

### DIFF
--- a/backend/src/main/java/com/devu/backend/api/like/LikeApiController.java
+++ b/backend/src/main/java/com/devu/backend/api/like/LikeApiController.java
@@ -8,10 +8,7 @@ import com.devu.backend.service.LikeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -19,6 +16,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class LikeApiController {
     private final LikeService likeService;
+
+    @GetMapping("/like")
+    public ResponseEntity<?> getLike(@RequestParam(name = "postId") Long postId) {
+        try {
+            Post post = likeService.findPostById(postId);
+            ResponseLikeSizeDto responseDto = ResponseLikeSizeDto.builder()
+                    .likeSize(post.getLikes().size())
+                    .postId(postId).build();
+            return ResponseEntity.ok().body(responseDto);
+        }catch (Exception e){
+            e.printStackTrace();
+            ResponseErrorDto errorDto = ResponseErrorDto.builder()
+                    .error(e.getMessage())
+                    .build();
+            return ResponseEntity.badRequest().body(errorDto);
+        }
+    }
 
     @PostMapping("/like")
     public ResponseEntity<?> addLike(@RequestBody RequestLikeDto requestLikeDto) {

--- a/backend/src/main/java/com/devu/backend/api/like/ResponseLikeSizeDto.java
+++ b/backend/src/main/java/com/devu/backend/api/like/ResponseLikeSizeDto.java
@@ -1,0 +1,15 @@
+package com.devu.backend.api.like;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseLikeSizeDto {
+    Long postId;
+    int likeSize;
+}


### PR DESCRIPTION
update:getLike Size API
- 게시글에 대한 좋아요의 갯수를 따로 얻을 수 있는 API
- 각 기능별로 조회 가능하는 메서드들은 따로 두는게 각 기능들에게 영향을 미치지 않음