### PR TITLE
update:HitApiController for get hits by postId

### DIFF
--- a/backend/src/main/java/com/devu/backend/api/hit/HitApiController.java
+++ b/backend/src/main/java/com/devu/backend/api/hit/HitApiController.java
@@ -1,0 +1,39 @@
+package com.devu.backend.api.hit;
+
+import com.devu.backend.controller.ResponseErrorDto;
+import com.devu.backend.entity.post.Post;
+import com.devu.backend.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api")
+public class HitApiController {
+    private final LikeService likeService;
+
+    @GetMapping("/hits")
+    public ResponseEntity<?> getHits(@RequestParam(name = "postId") Long postId) {
+        try {
+            Post post = likeService.findPostById(postId);
+            ResponseHitsDto responseDto = ResponseHitsDto.builder()
+                    .hits(post.getHit())
+                    .postId(post.getId()).build();
+            log.info("Post Id {} has {} hits", responseDto.getPostId(), responseDto.getHits());
+            return ResponseEntity.ok().body(responseDto);
+        }catch (Exception e) {
+            e.printStackTrace();
+            ResponseErrorDto errorDto = ResponseErrorDto.builder()
+                    .error(e.getMessage())
+                    .build();
+            return ResponseEntity.badRequest().body(errorDto);
+        }
+    }
+
+
+}

--- a/backend/src/main/java/com/devu/backend/api/hit/ResponseHitsDto.java
+++ b/backend/src/main/java/com/devu/backend/api/hit/ResponseHitsDto.java
@@ -1,0 +1,15 @@
+package com.devu.backend.api.hit;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseHitsDto {
+    Long hits;
+    Long postId;
+}

--- a/backend/src/main/java/com/devu/backend/api/like/LikeApiController.java
+++ b/backend/src/main/java/com/devu/backend/api/like/LikeApiController.java
@@ -1,6 +1,5 @@
 package com.devu.backend.api.like;
 
-import com.devu.backend.common.exception.UnlikedPostException;
 import com.devu.backend.controller.ResponseErrorDto;
 import com.devu.backend.entity.User;
 import com.devu.backend.entity.post.Post;
@@ -24,6 +23,7 @@ public class LikeApiController {
             ResponseLikeSizeDto responseDto = ResponseLikeSizeDto.builder()
                     .likeSize(post.getLikes().size())
                     .postId(postId).build();
+            log.info("Post Id {} has {} likes", responseDto.getPostId(), responseDto.getLikeSize());
             return ResponseEntity.ok().body(responseDto);
         }catch (Exception e){
             e.printStackTrace();


### PR DESCRIPTION
- HitApiController for get hits by postId
- Hit의 경우에도 상세페이지 조회를 통해서만 얻을 수 있음 -> 조회 API 통해 상세페이지를 거치지 않고도 가능