### PR TITLE
test: Test TokenService

### DIFF
--- a/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
+++ b/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
@@ -1,0 +1,57 @@
+package com.devu.backend.config.auth.token;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    private String secretKey = "Devu";
+    private long accessTokenValidTime = 1000L * 60 * 30; // 30분
+    private long refreshTokenValidTime = 1000L * 60 * 30 * (2 * 24 * 14); // 14일
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @Test
+    @DisplayName("액세스 토큰 생성")
+    void createAccessToken() {
+        String test = "test@gmail.com";
+
+        String jwt = tokenService.createAccessToken(test);
+        String subject = decodeJwt(jwt).getSubject();
+        Date issuedAt = decodeJwt(jwt).getIssuedAt();
+        Date expiration = decodeJwt(jwt).getExpiration();
+
+        assertEquals(subject, test);
+        assertEquals(expiration.getTime() - accessTokenValidTime, issuedAt.getTime());
+    }
+
+    private Claims decodeJwt(String jwt) {
+        return Jwts.parser().setSigningKey(secretKey)
+                .parseClaimsJws(jwt).getBody();
+    }
+
+    @Test
+    @DisplayName("리프레쉬 토큰 생성")
+    void createRefreshToken() {
+        String test = "test@gmail.com";
+
+        String jwt = tokenService.createRefreshToken(test);
+        String subject = decodeJwt(jwt).getSubject();
+        Date issuedAt = decodeJwt(jwt).getIssuedAt();
+        Date expiration = decodeJwt(jwt).getExpiration();
+
+        assertEquals(subject, test);
+        assertEquals(expiration.getTime() - refreshTokenValidTime, issuedAt.getTime());
+    }
+}

--- a/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
+++ b/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
@@ -5,6 +5,7 @@ import com.devu.backend.config.auth.UserDetailsServiceImpl;
 import com.devu.backend.entity.User;
 import com.devu.backend.repository.UserRepository;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -111,6 +112,26 @@ class TokenServiceTest {
         assertEquals(resolveToken, jwt);
     }
 
+    @Test
+    @DisplayName("토큰 시간이 유효한지 확인 - 유효")
+    void isTokenExpired_valid() {
+        String test = "test@gmail.com";
 
+        String jwt = tokenService.createAccessToken(test);
+        Boolean tokenExpired = tokenService.isTokenExpired(jwt);
+
+        assertEquals(tokenExpired, true);
+    }
+
+    @Test
+    @DisplayName("토큰이 시간이 유효한지 확인 - 무효")
+    void isTokenExpired_invalid() {
+        String test = "test@gmail.com";
+        String jwt = tokenService.createToken(test, 0);
+
+        assertThrows(ExpiredJwtException.class, () -> {
+            tokenService.isTokenExpired(jwt);
+        });
+    }
 
 }

--- a/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
+++ b/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
@@ -134,4 +134,30 @@ class TokenServiceTest {
         });
     }
 
+    @Test
+    @DisplayName("토큰 자체가 유효한지 - 유효")
+    void validateTokenExceptExpiration_valid() {
+        String test = "test@gmail.com";
+        User user = User.builder()
+                .email(test)
+                .build();
+        String jwt = tokenService.createAccessToken(test);
+        UserDetailsImpl userDetails = new UserDetailsImpl(user);
+
+        assertTrue(tokenService.validateTokenExceptExpiration(jwt, userDetails));
+    }
+
+    @Test
+    @DisplayName("토큰 자체가 유효한지 - 무효")
+    void validateTokenExceptExpiration_invalid() {
+        String test = "test@gmail.com";
+        String test1 = "test1@gmail.com";
+        User user = User.builder()
+                .email(test1)
+                .build();
+        String jwt = tokenService.createAccessToken(test);
+        UserDetailsImpl userDetails = new UserDetailsImpl(user);
+
+        assertFalse(tokenService.validateTokenExceptExpiration(jwt, userDetails));
+    }
 }

--- a/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
+++ b/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
@@ -15,11 +15,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
-
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class TokenServiceTest {
@@ -96,5 +97,20 @@ class TokenServiceTest {
 
         assertEquals(email, test);
     }
+
+    @Test
+    @DisplayName("헤더에서 액세스 토큰 얻기")
+    void resolveAccessToken() {
+        String test = "test@gmail.com";
+        String jwt = tokenService.createAccessToken(test);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        given(request.getHeader("X-AUTH-ACCESS-TOKEN")).willReturn(jwt);
+
+        String resolveToken = tokenService.resolveToken(request, "ACCESS");
+
+        assertEquals(resolveToken, jwt);
+    }
+
+
 
 }

--- a/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
+++ b/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
@@ -86,5 +86,15 @@ class TokenServiceTest {
         assertEquals(((UserDetails)authentication.getPrincipal()).getUsername(), test);
     }
 
+    @Test
+    @DisplayName("토큰으로 부터 유저 이메일 얻기")
+    void getUserEmail() {
+        String test = "test@gmail.com";
+        String jwt = tokenService.createAccessToken(test);
+
+        String email = tokenService.getUserEmail(jwt);
+
+        assertEquals(email, test);
+    }
 
 }

--- a/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
+++ b/backend/src/test/java/com/devu/backend/config/auth/token/TokenServiceTest.java
@@ -1,16 +1,25 @@
 package com.devu.backend.config.auth.token;
 
+import com.devu.backend.config.auth.UserDetailsImpl;
+import com.devu.backend.config.auth.UserDetailsServiceImpl;
+import com.devu.backend.entity.User;
+import com.devu.backend.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
 
 @ExtendWith(MockitoExtension.class)
 class TokenServiceTest {
@@ -21,6 +30,12 @@ class TokenServiceTest {
 
     @InjectMocks
     private TokenService tokenService;
+
+    @Mock
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Mock
+    private UserRepository userRepository;
 
     @Test
     @DisplayName("액세스 토큰 생성")
@@ -54,4 +69,22 @@ class TokenServiceTest {
         assertEquals(subject, test);
         assertEquals(expiration.getTime() - refreshTokenValidTime, issuedAt.getTime());
     }
+
+    @Test
+    @DisplayName("인증 얻기")
+    void getAuthentication() {
+        String test = "test@gmail.com";
+        User user = User.builder()
+                .email(test)
+                .build();
+        UserDetails userDetails = new UserDetailsImpl(user);
+        String jwt = tokenService.createAccessToken(test);
+        given(userDetailsService.loadUserByUsername(test)).willReturn(userDetails);
+
+        Authentication authentication = tokenService.getAuthentication(jwt);
+
+        assertEquals(((UserDetails)authentication.getPrincipal()).getUsername(), test);
+    }
+
+
 }


### PR DESCRIPTION
### 작업 개요
TokenService 단위 테스트

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [x] 테스트 코드 작성

### 작업 상세 내용
- createToken(토큰 생성)
  - createAccessToken(액세스 토큰 생성)
  - createRefreshToken(리프레쉬 토큰 생성)
- getAuthentication(인증 얻기)
- getUserEmail(토큰에서 useremail 얻기)
- resolveAccessToken(헤더에서 accesstoken 얻기)
- isTokenExpired(토큰 시간 유효한지)
  - isTokenExpired_valid (유효)
  - isTokenExpired_invalid (무효)
- validateTokenExceptExpiration(토큰 자체 유효한지)
  - validateTokenExceptExpiration_valid (유효)
  - validateTokenExceptExpiration_invalid (무효)
 
### 생각해볼 문제
secretKey, accessTokenValidTime, refreshTokenValidTime을 숨겨서 사용하고 싶은데 그렇다면 설정파일인 property에서 @value로 주입 받아야 되는가? 그렇게 되면 Spring context를 사용하게 되는데 독립적인 단위 테스트가 맞을까? 테스트환경 설정파일에서 할 수 있을지 좀 찾아봐야겠다.

+tmi: pr할 때 다시 보니깐 더 수정할 곳이 보이네요ㅋㅋㅋ(주석으로 남겨놓고 새로 수정하겠습니다!)