### PR TITLE
fix: Proxy in package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "proxy": "http://54.180.29.69:8080",
+  "proxy": "http://15.165.205.119:8081",
   "name": "client",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
### 에러 해결
서버 주소가 `http://54.180.29.69:8080` -> `http://15.165.205.119`로 바뀌면서 frontend/package.json에 있는 Proxy도 수정

```
Proxy error: Could not proxy request /community/chats?page=0&tags=&s=&status=&order= from localhost:3000 to http://54.180.29.69:8080.
See https://nodejs.org/api/errors.html#errors_common_system_errors for more information (ETIMEDOUT).
```
package.json에 있는 Proxy 수정하기 전까지 위 오류(api 요청할 때 마다 개발자모드 네트워크 상에 pending 후 500 error)가 계속 발생했는데 Proxy 바꾸고 해결됨.