### PR TITLE
fix: JWT silentRefresh

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-// import axios from 'axios';
+import axios from "axios";
 import "./App.css";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Navbar from "./components/Navbar/Navbar";
@@ -27,26 +27,27 @@ import ChatsModify from "./components/Forum/Chats/ChatsModify";
 
 function App() {
   const JWT_EXPIRY_TIME = 30 * 60 * 1000; // 만료 시간 (30분)
-  // const onSilentRefresh = async () => {
-  //   await axios
-  //     .post(process.env.REACT_APP_DB_HOST + '/silent-refresh')
-  //     .then((response) => {
-  //       console.log(response);
-  //       if (response.headers['x-auth-access-token']) {
-  //         localStorage.setItem('accessToken', response.headers['x-auth-access-token']);
-  //       }
-  //       setInterval(onSilentRefresh, JWT_EXPIRY_TIME - 60000); // accessToken 만료하기 1분 전에 로그인 연장
-  //       console.log("Timeout-App.js");
-  //     })
-  //     .catch((res) => {
-  //       console.log(res);
-  //       alert(JSON.parse(res.request.response).error); // 이메일, 비밀번호 오류 출력
-  //     });
-  // };
+  const onSilentRefresh = async () => {
+    await axios
+      .post(process.env.REACT_APP_DB_HOST + "/silent-refresh")
+      .then((response) => {
+        console.log(response);
+        if (response.headers["x-auth-access-token"]) {
+          localStorage.setItem(
+            "accessToken",
+            response.headers["x-auth-access-token"]
+          );
+        }
+        setInterval(onSilentRefresh, JWT_EXPIRY_TIME - 60000); // accessToken 만료하기 1분 전에 로그인 연장, setInterval은 해당 주기마다 함수 실행
+        console.log("setInterval-App.js");
+      })
+      .catch((res) => console.log(res));
+  };
 
-  // if (performance.navigation.type === 1) { //새로고침하면 바로 로그인 연장(토큰 갱신)
-  //   onSilentRefresh();
-  // }
+  if (performance.navigation.type === 1) {
+    //새로고침하면 바로 로그인 연장(토큰 갱신)
+    onSilentRefresh();
+  }
 
   return (
     <>

--- a/frontend/src/components/Navbar/LoginButton.js
+++ b/frontend/src/components/Navbar/LoginButton.js
@@ -49,7 +49,8 @@ function LoginButton() {
           "accessToken",
           response.headers["x-auth-access-token"]
         );
-        window.location.reload(false);
+        // window.location.reload(false); // 새로고침 필요하지 않아 주석처리.
+        setTimeout(onSilentRefresh, JWT_EXPIRY_TIME - 60000); // setTimeout은 해당 시간 후에 함수 호출
       })
       .catch(
         (e) => alert(JSON.parse(e.request.response).error) // 이메일, 비밀번호 오류 출력
@@ -67,13 +68,10 @@ function LoginButton() {
             res.headers["x-auth-access-token"]
           );
         }
-        setInterval(onSilentRefresh, JWT_EXPIRY_TIME - 60000); // accessToken 만료하기 1분 전에 로그인 연장
-        console.log("Timeout-loginButton.js");
+        setInterval(onSilentRefresh, JWT_EXPIRY_TIME - 60000); // accessToken 만료하기 1분 전에 로그인 연장, setInterval은 해당 주기마다 함수 실행
+        console.log("setInterval-loginButton.js");
       })
-      .catch(
-        (e) => console.log(e)
-        // alert(JSON.parse(res.request.response).error); // 이메일, 비밀번호 오류 출력
-      );
+      .catch((e) => console.log(e));
   };
 
   return (


### PR DESCRIPTION
지난 학기에 주석 처리했던 `silentRefresh` 부분 다시 살펴보고 필요하지 않은 코드는 삭제함.
(LoginButton.js -> handleLogin 함수의 axios 처리 중 로그인 누른 후 강제 새로고침하는 코드는 불필요하기 때문에 삭제)
지난 학기에도 문제였던 `silentRefresh`가 2번 호출되는 문제는 계속 찾아보고 있으나 아직 해결하지 못함.
로그아웃했을 때 저장된 accessToken, refreshToken 정상적으로 삭제되는 것은 확인했음.