### PR TITLE
fix:Admin 페이지 받은 댓글 및 좋아요 갯수 에러

### DIFF
--- a/backend/src/main/java/com/devu/backend/controller/admin/AdminController.java
+++ b/backend/src/main/java/com/devu/backend/controller/admin/AdminController.java
@@ -29,7 +29,7 @@ public class AdminController {
     private final EmailService emailService;
 
     @GetMapping
-    private String adminHome(Model model) {
+    public String adminHome(Model model) {
         List<User> users = userService.getUsers();
         List<UserDTO> userDTOS = new ArrayList<>();
         int sumOfPosts = 0;
@@ -71,7 +71,7 @@ public class AdminController {
     }
 
     @PostMapping("/user")
-    private String createMockUser(Model model) {
+    public String createMockUser(Model model) {
         String username = emailService.createKey();
         String email = username + "@test.com";
         String password = "test";
@@ -88,37 +88,37 @@ public class AdminController {
 
 
     @PostMapping("/{userId}")
-    private String deleteUser(@PathVariable Long userId, Model model) {
+    public String deleteUser(@PathVariable Long userId, Model model) {
         log.info("userId = {}", userId);
         userService.deleteUser(userId);
         return "redirect:/admin";
     }
 
     @GetMapping("/userInfo")
-    private String getUserInfo(@RequestParam Long userId, Model model) {
+    public String getUserInfo(@RequestParam Long userId, Model model) {
         log.info("Query parameter = {}", userId);
         User user = userService.getUserById(userId);
         List<Post> allPosts = postService.findAllPosts(user);
-        int receiveLikes = 0;
-        int receiveComments = 0;
-        calculateReceiveValue(allPosts, receiveLikes, receiveComments);
         UserDTO userDTO = UserDTO.builder()
                 .username(user.getUsername())
                 .userId(user.getId())
                 .email(user.getEmail())
-                .receivedComments(receiveComments)
-                .receivedLikes(receiveLikes)
                 .build();
+        calculateReceiveValue(allPosts, userDTO);
         model.addAttribute("user", userDTO);
         addStudyAttribute(model, user);
         return "user-info";
     }
 
-    private void calculateReceiveValue(List<Post> allPosts, int receiveLikes, int receiveComments) {
+    private void calculateReceiveValue(List<Post> allPosts,UserDTO userDTO) {
+        int receiveLikes = 0;
+        int receiveComments = 0;
         for (Post post : allPosts) {
             receiveLikes += post.getLikes().size();
             receiveComments += post.getComments().size();
         }
+        userDTO.setReceivedLikes(receiveLikes);
+        userDTO.setReceivedComments(receiveLikes);
     }
 
     private void addStudyAttribute(Model model, User user) {
@@ -129,7 +129,7 @@ public class AdminController {
     }
 
     @PostMapping("/post/{userId}")
-    private String createMockPost(@RequestParam String type,
+    public String createMockPost(@RequestParam String type,
                                   @PathVariable Long userId ,
                                   RedirectAttributes redirectAttributes) {
         try {

--- a/backend/src/main/java/com/devu/backend/service/PostService.java
+++ b/backend/src/main/java/com/devu/backend/service/PostService.java
@@ -172,11 +172,7 @@ public class PostService {
 
 
     public List<Post> findAllPosts(User user) {
-        List<Post> posts = postRepository.findAllByUserId(user.getId()).orElseThrow(UserNotFoundException::new);
-        if (posts.size() == 0) {
-            throw new PostNotFoundException();
-        }
-        return posts;
+        return postRepository.findAllByUserId(user.getId()).orElseThrow(UserNotFoundException::new);
     }
 
     public Page<PostResponseDto> findAllChats(Pageable pageable,String order,String s) {


### PR DESCRIPTION
## 문제 상황
<img width="1353" alt="스크린샷 2022-08-11 오후 6 20 27" src="https://user-images.githubusercontent.com/64846408/184102644-665dc62d-58d2-4a5f-9f84-bdad5f921017.png">
 
 - 위의 이미지처럼 현재 User가 작성한 포스트에 댓글이 있음에도 카운트가 되지 않고 0으로 렌더링 되는 문제 발생
 - 게시글이 없는 유저의 상세 정보 어드민 페이지(/admin/user-info)로 접속할 경우 에러 발생
