### PR TITLE
feat,test:이메일 검증 키 검증 추가

### DIFF
--- a/backend/src/main/java/com/devu/backend/controller/user/UserController.java
+++ b/backend/src/main/java/com/devu/backend/controller/user/UserController.java
@@ -34,7 +34,7 @@ public class UserController {
                                         BindingResult bindingResult) {
         try {
             if (bindingResult.hasErrors()) {
-                return ResponseEntity.badRequest().body(bindingResult.getFieldError());
+                return ResponseEntity.badRequest().body(bindingResult.getFieldError().getDefaultMessage());
             }
             String email = dto.getEmail();
             if (userService.isEmailExists(email)) {
@@ -70,7 +70,13 @@ public class UserController {
     // 2nd logic in create User
     // 회원가입 Form에서 이메일 검증 api => Form Data로 넘어와야함
     @PostMapping("/key")
-    private ResponseEntity<?> getKeyFromUser(@RequestParam String postKey) {
+    private ResponseEntity<?> getKeyFromUser(
+            @RequestBody @Validated UserKeyRequestDto dto,
+            BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity.badRequest().body(bindingResult.getFieldError().getDefaultMessage());
+        }
+        String postKey = dto.getUserKey();
         try {
             userService.updateUserConfirm(postKey);
             return ResponseEntity.ok(HttpStatus.OK);

--- a/backend/src/main/java/com/devu/backend/controller/user/UserKeyRequestDto.java
+++ b/backend/src/main/java/com/devu/backend/controller/user/UserKeyRequestDto.java
@@ -12,5 +12,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserKeyRequestDto {
     @UserKeyCheck
+
     private String userKey;
 }

--- a/backend/src/main/java/com/devu/backend/controller/user/UserKeyRequestDto.java
+++ b/backend/src/main/java/com/devu/backend/controller/user/UserKeyRequestDto.java
@@ -1,0 +1,16 @@
+package com.devu.backend.controller.user;
+
+import com.devu.backend.controller.validation.UserKeyCheck;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserKeyRequestDto {
+    @UserKeyCheck
+    private String userKey;
+}

--- a/backend/src/main/java/com/devu/backend/controller/validation/UserKeyCheck.java
+++ b/backend/src/main/java/com/devu/backend/controller/validation/UserKeyCheck.java
@@ -9,9 +9,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = EmailCheckValidator.class)
-public @interface EmailCheck {
+public @interface UserKeyCheck {
+    String ERROR_MESSAGE = "잘못된 인증 키 양식입니다.";
 
-    String ERROR_MESSAGE = "잘못된 이메일 양식입니다.";
 
     String message() default ERROR_MESSAGE;
 

--- a/backend/src/main/java/com/devu/backend/controller/validation/UserKeyCheck.java
+++ b/backend/src/main/java/com/devu/backend/controller/validation/UserKeyCheck.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
-@Constraint(validatedBy = EmailCheckValidator.class)
+@Constraint(validatedBy = UserKeyValidator.class)
 public @interface UserKeyCheck {
     String ERROR_MESSAGE = "잘못된 인증 키 양식입니다.";
 

--- a/backend/src/main/java/com/devu/backend/controller/validation/UserKeyValidator.java
+++ b/backend/src/main/java/com/devu/backend/controller/validation/UserKeyValidator.java
@@ -1,0 +1,14 @@
+package com.devu.backend.controller.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class UserKeyValidator implements ConstraintValidator<UserKeyCheck, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
+        return value.length() == 8;
+    }
+}

--- a/backend/src/test/java/com/devu/backend/controller/user/UserControllerTest.java
+++ b/backend/src/test/java/com/devu/backend/controller/user/UserControllerTest.java
@@ -1,10 +1,12 @@
 package com.devu.backend.controller.user;
 
+import com.devu.backend.controller.validation.EmailCheck;
 import com.devu.backend.entity.User;
 import com.devu.backend.repository.UserRepository;
 import com.devu.backend.service.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/devu/backend/controller/user/UserControllerTest.java
+++ b/backend/src/test/java/com/devu/backend/controller/user/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.devu.backend.controller.user;
 
 import com.devu.backend.controller.validation.EmailCheck;
+import com.devu.backend.controller.validation.UserKeyCheck;
 import com.devu.backend.entity.User;
 import com.devu.backend.repository.UserRepository;
 import com.devu.backend.service.UserService;
@@ -60,7 +61,7 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("이메일 입력 Form - 실패")
+    @DisplayName("이메일 입력 검증 - 실패")
     void emailValidationFail() throws Exception {
         String url = "/email";
         UserEmailRequestDto dto = UserEmailRequestDto.builder()
@@ -84,7 +85,7 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("이메일 입력 Form - 성공")
+    @DisplayName("이메일 입력 검증 - 성공")
     void emailValidationSuccess() throws Exception {
         JSONParser parser = new JSONParser();
         String url = "/email";
@@ -187,6 +188,30 @@ class UserControllerTest {
         User user = userRepository.findByEmail(dto.getEmail()).orElseThrow();
 
         assertNotEquals("test-key", user.getEmailAuthKey());
+    }
+
+    @Test
+    @DisplayName("이메일 검증키 검증 - 실패")
+    void userKeyValidationFail() throws Exception {
+        String url = "/key";
+        UserKeyRequestDto dto = UserKeyRequestDto.builder()
+                .userKey("").build();
+        String content = objectMapper.writeValueAsString(dto);
+
+        ResultActions actions = mockMvc.perform(post(url)
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        actions.andExpect(status().isBadRequest())
+                .andExpect(result -> {
+                    MockHttpServletResponse response = result.getResponse();
+                    String contentAsString = response.getContentAsString();
+                    assertThat(contentAsString).isEqualTo(UserKeyCheck.ERROR_MESSAGE);
+                })
+                .andDo(document("{method-name}",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())));;
     }
 
     @Test


### PR DESCRIPTION
### 작업 개요
- 기존의 검증없이 서버에 들어오던 이메일 검증키(8자리)에 대한 검증 기능 추가 풀리퀘입니다.
- 어노테이션 기반의 검증으로 구현했으며 검증 로직의 경우 검증 키의 조건인 8자리에 맞지 않은 데이터가 들어올 경우 검증 진행합니다.
- 추가로 이메일 양식에 대한 검증 테스트 코드도 추가했습니다.(`yu.ac.kr` 또는 `ynu.ac.kr`만 허용하는 검증)
- 마찬가지로 이메일 검증키의 양식(8자리)에 대한 검증 테스트 코드도 추가했습니다.

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [x] 테스트 코드 작성
- [ ]  문서화