### PR TITLE
feat: 취업정보 검색 추가 및 리팩터링

### DIFF
--- a/backend/src/main/java/com/devu/backend/api/position/PositionController.java
+++ b/backend/src/main/java/com/devu/backend/api/position/PositionController.java
@@ -31,9 +31,9 @@ public class PositionController {
     }
 
     @GetMapping("/naver")
-    public ResponseEntity<?> getNaver(@PageableDefault(size = 20) Pageable pageable) {
+    public ResponseEntity<?> getNaver(String keyword, @PageableDefault(size = 20) Pageable pageable) {
         try {
-            return ResponseEntity.ok(positionService.getNaver(pageable));
+            return ResponseEntity.ok(positionService.getNaver(keyword, pageable));
         } catch (Exception e) {
             e.printStackTrace();
             ResponseErrorDto errorDto = ResponseErrorDto.builder()
@@ -44,9 +44,9 @@ public class PositionController {
     }
 
     @GetMapping("/kakao")
-    public ResponseEntity<?> getKakao(@PageableDefault(size = 20) Pageable pageable) {
+    public ResponseEntity<?> getKakao(String keyword, @PageableDefault(size = 20) Pageable pageable) {
         try {
-            return ResponseEntity.ok(positionService.getKakao(pageable));
+            return ResponseEntity.ok(positionService.getKakao(keyword, pageable));
         } catch (Exception e) {
             e.printStackTrace();
             ResponseErrorDto errorDto = ResponseErrorDto.builder()
@@ -57,9 +57,9 @@ public class PositionController {
     }
 
     @GetMapping("/line")
-    public ResponseEntity<?> getLine(@PageableDefault(size = 20) Pageable pageable) {
+    public ResponseEntity<?> getLine(String keyword, @PageableDefault(size = 20) Pageable pageable) {
         try {
-            return ResponseEntity.ok(positionService.getLine(pageable));
+            return ResponseEntity.ok(positionService.getLine(keyword, pageable));
         } catch (Exception e) {
             e.printStackTrace();
             ResponseErrorDto errorDto = ResponseErrorDto.builder()
@@ -70,9 +70,9 @@ public class PositionController {
     }
 
     @GetMapping("/coupang")
-    public ResponseEntity<?> getCoupang(@PageableDefault(size = 20) Pageable pageable) {
+    public ResponseEntity<?> getCoupang(String keyword, @PageableDefault(size = 20) Pageable pageable) {
         try {
-            return ResponseEntity.ok(positionService.getCoupang(pageable));
+            return ResponseEntity.ok(positionService.getCoupang(keyword, pageable));
         } catch (Exception e) {
             e.printStackTrace();
             ResponseErrorDto errorDto = ResponseErrorDto.builder()
@@ -83,9 +83,9 @@ public class PositionController {
     }
 
     @GetMapping("/baemin")
-    public ResponseEntity<?> getBaemin(@PageableDefault(size = 20) Pageable pageable) {
+    public ResponseEntity<?> getBaemin(String keyword, @PageableDefault(size = 20) Pageable pageable) {
         try {
-            return ResponseEntity.ok(positionService.getBaemin(pageable));
+            return ResponseEntity.ok(positionService.getBaemin(keyword, pageable));
         } catch (Exception e) {
             e.printStackTrace();
             ResponseErrorDto errorDto = ResponseErrorDto.builder()

--- a/backend/src/main/java/com/devu/backend/api/position/PositionController.java
+++ b/backend/src/main/java/com/devu/backend/api/position/PositionController.java
@@ -18,9 +18,9 @@ public class PositionController {
     private final PositionService positionService;
 
     @GetMapping("/all")
-    public ResponseEntity<?> getAllPosition(@PageableDefault(size = 20) Pageable pageable) {
+    public ResponseEntity<?> getAllPosition(String keyword, @PageableDefault(size = 20) Pageable pageable) {
         try {
-            return ResponseEntity.ok(positionService.getAllPosition(pageable));
+            return ResponseEntity.ok(positionService.getAllPosition(keyword, pageable));
         } catch (Exception e) {
             e.printStackTrace();
             ResponseErrorDto errorDto = ResponseErrorDto.builder()

--- a/backend/src/main/java/com/devu/backend/repository/PositionRepository.java
+++ b/backend/src/main/java/com/devu/backend/repository/PositionRepository.java
@@ -7,9 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PositionRepository extends JpaRepository<Position, Long> {
-    Page<Position> findByCompany(CompanyType company, Pageable pageable);
-
-    long countByCompany(CompanyType company);
-
     Page<Position> findByTitleContainingIgnoreCase(String keyword, Pageable pageable);
+
+    Page<Position> findByTitleContainingIgnoreCaseAndCompany(String keyword, CompanyType company, Pageable pageable);
 }

--- a/backend/src/main/java/com/devu/backend/repository/PositionRepository.java
+++ b/backend/src/main/java/com/devu/backend/repository/PositionRepository.java
@@ -10,4 +10,6 @@ public interface PositionRepository extends JpaRepository<Position, Long> {
     Page<Position> findByCompany(CompanyType company, Pageable pageable);
 
     long countByCompany(CompanyType company);
+
+    Page<Position> findByTitleContainingIgnoreCase(String keyword, Pageable pageable);
 }

--- a/backend/src/main/java/com/devu/backend/service/PositionService.java
+++ b/backend/src/main/java/com/devu/backend/service/PositionService.java
@@ -291,10 +291,21 @@ public class PositionService {
             collectCoupang(i);
     }
 
-    public PositionDto getAllPosition(Pageable pageable) {
-        Page<PositionResponseDto> allPosition = positionRepository.findAll(pageable).map(PositionResponseDto::new);
-        long size = positionRepository.count();
-        return PositionDto.builder().size(size)
+    public PositionDto getAllPosition(String keyword, Pageable pageable) {
+        return getPositionDto(getPositionResponseDto(keyword, pageable));
+    }
+
+    private Page<PositionResponseDto> getPositionResponseDto(String keyword, Pageable pageable) {
+        return getPosition(keyword, pageable)
+                .map(PositionResponseDto::new);
+    }
+
+    private Page<Position> getPosition(String keyword, Pageable pageable) {
+        return positionRepository.findByTitleContainingIgnoreCase(keyword, pageable);
+    }
+
+    private PositionDto getPositionDto(Page<PositionResponseDto> allPosition) {
+        return PositionDto.builder().size(allPosition.getTotalElements())
                 .positions(allPosition.getContent())
                 .build();
     }

--- a/backend/src/main/java/com/devu/backend/service/PositionService.java
+++ b/backend/src/main/java/com/devu/backend/service/PositionService.java
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
-import java.util.List;
 
 @Slf4j
 @Service
@@ -310,22 +309,33 @@ public class PositionService {
                 .build();
     }
 
-    public PositionDto getNaver(Pageable pageable) {
-        return getPositionDto(pageable, CompanyType.NAVER);
+    public PositionDto getNaver(String keyword, Pageable pageable) {
+        return getPositionDto(getPositionResponseDtoByCompany(keyword, pageable, CompanyType.NAVER));
     }
 
-    private PositionDto getPositionDto(Pageable pageable, CompanyType company) {
-        long size = positionRepository.countByCompany(company);
-        return PositionDto.builder().size(size)
-                .positions(getPositionByCompany(pageable, company))
-                .build();
+    private Page<PositionResponseDto> getPositionResponseDtoByCompany(String keyword, Pageable pageable, CompanyType company) {
+        return getPositionByCompany(keyword, pageable, company).map(PositionResponseDto::new);
     }
 
-    private List<PositionResponseDto> getPositionByCompany(Pageable pageable, CompanyType company) {
-        Page<PositionResponseDto> positionsByCompany = positionRepository.findByCompany(company, pageable).map(PositionResponseDto::new);
-        return positionsByCompany.getContent();
+    private Page<Position> getPositionByCompany(String keyword, Pageable pageable, CompanyType company) {
+        return positionRepository.findByTitleContainingIgnoreCaseAndCompany(keyword, company, pageable);
     }
 
+    public PositionDto getKakao(String keyword, Pageable pageable) {
+        return getPositionDto(getPositionResponseDtoByCompany(keyword, pageable, CompanyType.KAKAO));
+    }
+
+    public PositionDto getLine(String keyword, Pageable pageable) {
+        return getPositionDto(getPositionResponseDtoByCompany(keyword, pageable, CompanyType.LINE));
+    }
+
+    public PositionDto getCoupang(String keyword, Pageable pageable) {
+        return getPositionDto(getPositionResponseDtoByCompany(keyword, pageable, CompanyType.COUPANG));
+    }
+
+    public PositionDto getBaemin(String keyword, Pageable pageable) {
+        return getPositionDto(getPositionResponseDtoByCompany(keyword, pageable, CompanyType.BAEMIN));
+    }
 
     public static String removeEmoji(String input){
         if(input == null)return null;
@@ -341,21 +351,5 @@ public class PositionService {
             sb.append(input.charAt(i));
         }
         return sb.toString();
-    }
-
-    public PositionDto getKakao(Pageable pageable) {
-        return getPositionDto(pageable, CompanyType.KAKAO);
-    }
-
-    public PositionDto getLine(Pageable pageable) {
-        return getPositionDto(pageable, CompanyType.LINE);
-    }
-
-    public PositionDto getCoupang(Pageable pageable) {
-        return getPositionDto(pageable, CompanyType.COUPANG);
-    }
-
-    public PositionDto getBaemin(Pageable pageable) {
-        return getPositionDto(pageable, CompanyType.BAEMIN);
     }
 }


### PR DESCRIPTION
### 작업 개요
feat: 취업정보 검색 추가 및 리팩터링

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성

### 작업 상세 내용
Position을 반환하는 과정을 보면 3가지 과정으로 나누어집니다. 만약 더 좋은 구조가 있으면 의견주세요!
DB -> Position -> PositionReponseDto -> PositionDto(size, List(PositionResponseDto) )
- 취업 정보 검색 추가 (검색하려면 Parameter로 keyword 보내시면 됩니다.)
  - DB에서 가져오는 게 getPosition (채용공고 제목에 대소문자 상관없이 포함되면 검색되게 했습니다.)
  - Position을 PositionResponseDto으로 변환하는 과정이 getPositionResponseDto
  - 사이즈와 PositionResponseDto를 PositionDto에 추가하는 과정이 getPositionDto입니다.
 
- 리팩토링 같은 경우도 하나의 메서드에 하나의 역활만 주는 구조로 나눴고 필요없는 지역변수 같은 경우 삭제했습니다.
가독성도 어떠신지 피드백 부탁드려요!